### PR TITLE
Custom layout changes in VizLayout

### DIFF
--- a/packages/plutono-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/plutono-ui/src/components/VizLayout/VizLayout.tsx
@@ -35,7 +35,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     return <div style={containerStyle}>{children(width, height)}</div>;
   }
 
-  const { placement, maxHeight, maxWidth } = legend.props;
+  const { placement, maxWidth } = legend.props;
 
   let size: VizSize | null = null;
 
@@ -48,11 +48,11 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
   switch (placement) {
     case 'bottom':
       containerStyle.flexDirection = 'column';
-      legendStyle.maxHeight = maxHeight;
-
-      if (legendMeasure) {
-        size = { width, height: height - legendMeasure.height };
-      }
+      const legendHeight = height * 0.2;
+      const vizHeight = height - legendHeight;
+      size = { width, height: vizHeight };
+      legendStyle.height = `${legendHeight}px`;
+      legendStyle.overflowY = 'auto';
       break;
     case 'right':
       containerStyle.flexDirection = 'row';


### PR DESCRIPTION
1.The code divides the available pie chart space between a chart and its legend.
2.20% is allocated to the legend, and the rest is used for the pie chart.
3.The legend section is made scrollable if they are more.