### PR TITLE
Increased dropdown limit from 3000 to 4500

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/influxdb-client-go/v2/api"
 )
 
-const maxPointsEnforceFactor float64 = 30
+const maxPointsEnforceFactor float64 = 45
 
 // executeQuery runs a flux query using the queryModel to interpolate the query and the runner to execute it.
 // maxSeries somehow limits the response.

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -34,7 +34,7 @@ export const initialState: OptionsPickerState = {
   multi: false,
 };
 
-export const OPTIONS_LIMIT = 3000;
+export const OPTIONS_LIMIT = 4500;
 
 const getTags = (model: VariableWithMultiSupport) => {
   if (isQuery(model) && Array.isArray(model.tags)) {

--- a/readme_hlxdm.txt
+++ b/readme_hlxdm.txt
@@ -1,0 +1,20 @@
+Plutono v7.5.37-1:
+
+- Added data link support for the Pie charts.
+- Increased the variable dropdown limit from 1000 to 3000.
+  -> Modified files:
+      - pkg/tsdb/influxdb/flux/executor.go
+      - public/app/features/variables/pickers/OptionsPicker/reducer.ts
+
+-----------------------------------------------------------------------
+
+Plutono v7.5.37-2:
+- Increased the variable dropdown limit from 3000 to 4500 .
+  -> Modified files: 
+        -  pkg/tsdb/influxdb/flux/executor.go
+        -  public/app/features/variables/pickers/OptionsPicker/reducer.ts
+  
+
+- Made the Pie chart panel size fixed and added a scrollable legend for improved layout.
+  -> Modified files:
+        - packages/plutono-ui/src/components/VizLayout/VizLayout.tsx


### PR DESCRIPTION
Increased dropdown limit from 3000 to 4500
  -> Modified files: 
        -  pkg/tsdb/influxdb/flux/executor.go
        -  public/app/features/variables/pickers/OptionsPicker/reducer.ts
Added readme file